### PR TITLE
patch_0.1.2: Initialize ArtifactoryRuby.new in Runner.start

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artificer_ruby (0.1.0)
+    artificer_ruby (0.1.2)
       artifactory (~> 3.0)
       rufus-scheduler (~> 3.6)
 

--- a/lib/artificer_ruby.rb
+++ b/lib/artificer_ruby.rb
@@ -45,6 +45,7 @@ module ArtificerRuby
 
       @scheduler.cron @cfg.schedule do
         begin
+          ArtificerRuby.new
           ArtificerRuby.run_routines
         rescue StandardError => e
           puts e

--- a/lib/artificer_ruby/version.rb
+++ b/lib/artificer_ruby/version.rb
@@ -1,3 +1,3 @@
 module ArtificerRuby
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Runner.start was running a default Artifactory.config. It now runs ArtificerRuby.new and #connect_to_artifactory(cfg) to initialize a connection before running #run_routines.